### PR TITLE
Adjust contract of create-archive-from-port to match documentation

### DIFF
--- a/aws/glacier.rkt
+++ b/aws/glacier.rkt
@@ -406,7 +406,7 @@
   (finish-multipart-upload name id len archive-tree-hash))
 
 (define/contract (create-archive-from-port vault port desc #:part-size [part-size 1MB])
-  (string? input-port? string? #:part-size valid-part-size? . -> . string?)
+  ((string? input-port? string?) (#:part-size valid-part-size?) . ->* . string?)
   (define id (start-multipart-upload vault part-size desc))
   (define ctx (make-upload-ctx))
   (let loop ([i 0]


### PR DESCRIPTION
Trivial change...

The documentation for `create-archive-from-port` says:

```
(create-archive-from-port  vault-name                        
                           port                              
                           description                       
                          [#:part-size part-size]) -> string?
  vault-name : string?                                       
  port : input-port?                                         
  description : string?                                      
  part-size : exact-nonnegative-integer? = (* 1024 1024)
```

This suggests that keyword `#:part-size` is optional, but the original contract requires it to be present.
