### PR TITLE
Provide get-metric-statistics

### DIFF
--- a/aws/cw.rkt
+++ b/aws/cw.rkt
@@ -241,7 +241,7 @@
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
-(define/contract (get-metric-statistics #:metric-name metric-name
+(define/contract/provide (get-metric-statistics #:metric-name metric-name
                                         #:namespace namespace
                                         #:statistics statistics
                                         #:unit unit


### PR DESCRIPTION
I think there was a "provide" missing in get-metric-statistic's definition. 